### PR TITLE
Updating jasperreports version to 6 so we can compile reports under java8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 		<dependency>
 			<groupId>net.sf.jasperreports</groupId>
 			<artifactId>jasperreports</artifactId>
-			<version>5.2.0</version>
+			<version>6.0.0</version>
 		</dependency>
 
 		<dependency>
@@ -94,7 +94,7 @@
 		<dependency>
 			<groupId>net.sf.jasperreports</groupId>
 			<artifactId>jasperreports-fonts</artifactId>
-			<version>4.0.0</version>
+			<version>6.0.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Basically I updated the jasperreports and jasperreports-fonts for 6.0.0 because versions before depend on jdtcore 3.1.0 that is not compatible with java8 causing the compilation to fail.