### PR TITLE
Handling versions since 3.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-project</artifactId>
+			<version>2.2.1</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.maven.shared</groupId>
 			<artifactId>maven-plugin-testing-harness</artifactId>
 			<version>1.1</version>
@@ -79,7 +84,8 @@
 		<dependency>
 			<groupId>net.sf.jasperreports</groupId>
 			<artifactId>jasperreports</artifactId>
-			<version>6.1.1</version>
+			<version>4.6.0</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
@@ -97,7 +103,8 @@
 		<dependency>
 			<groupId>net.sf.jasperreports</groupId>
 			<artifactId>jasperreports-fonts</artifactId>
-			<version>6.0.0</version>
+			<version>4.0.0</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/com/alexnederlof/jasperreport/Jasper353Configurator.java
+++ b/src/main/java/com/alexnederlof/jasperreport/Jasper353Configurator.java
@@ -1,0 +1,44 @@
+package com.alexnederlof.jasperreport;
+
+import static org.apache.commons.lang.StringUtils.join;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import net.sf.jasperreports.engine.util.JRProperties;
+
+@SuppressWarnings("deprecation")
+public class Jasper353Configurator implements JasperConfigurator {
+
+	@Override
+	public void configure(JasperReporter reporter) {
+
+		JRProperties.backupProperties();
+		
+		String compiler = reporter.getCompiler();
+		if (compiler != null) {
+			JRProperties.setProperty(JRProperties.COMPILER_CLASS, compiler);
+		}
+
+		List<String> classpathElements = reporter.getClasspathElements();
+		if (!classpathElements.isEmpty()) {
+			JRProperties.setProperty(JRProperties.COMPILER_CLASSPATH, join(classpathElements, reporter.getPathSeparatorChar()));
+		}
+
+		JRProperties.setProperty(JRProperties.COMPILER_XML_VALIDATION, reporter.getXmlValidation());
+
+		Map<String, String> additionalProperties = reporter.getAdditionalProperties();
+		if (additionalProperties != null) {
+			for (Entry<String, String> property : additionalProperties.entrySet()) {
+				JRProperties.setProperty(property.getKey(), property.getValue());
+			}
+		}
+	}
+
+	@Override
+	public void revert() {
+		JRProperties.restoreProperties();
+	}
+	
+}

--- a/src/main/java/com/alexnederlof/jasperreport/Jasper460Configurator.java
+++ b/src/main/java/com/alexnederlof/jasperreport/Jasper460Configurator.java
@@ -1,0 +1,38 @@
+package com.alexnederlof.jasperreport;
+
+import java.util.Map;
+
+import net.sf.jasperreports.engine.DefaultJasperReportsContext;
+import net.sf.jasperreports.engine.JRPropertiesUtil;
+import net.sf.jasperreports.engine.design.JRCompiler;
+import net.sf.jasperreports.engine.design.JRJdtCompiler;
+import net.sf.jasperreports.engine.xml.JRReportSaxParserFactory;
+
+public class Jasper460Configurator implements JasperConfigurator {
+
+	@Override
+	public void configure(JasperReporter reporter) {
+		
+		DefaultJasperReportsContext jrContext = DefaultJasperReportsContext.getInstance();
+
+		boolean xmlValidation = reporter.getXmlValidation();
+		String compiler = reporter.getCompiler();
+		Map<String, String> additionalProperties = reporter.getAdditionalProperties();
+
+		jrContext.setProperty(JRReportSaxParserFactory.COMPILER_XML_VALIDATION, String.valueOf(xmlValidation));
+		jrContext.setProperty(JRCompiler.COMPILER_PREFIX, compiler == null ? JRJdtCompiler.class.getName() : compiler);
+		jrContext.setProperty(JRCompiler.COMPILER_KEEP_JAVA_FILE, Boolean.FALSE.toString());
+
+		if (additionalProperties != null) {
+			JRPropertiesUtil propertiesUtil = JRPropertiesUtil.getInstance(jrContext);
+			for (Map.Entry<String, String> additionalProperty : additionalProperties.entrySet()) {
+				propertiesUtil.setProperty(additionalProperty.getKey(), additionalProperty.getValue());
+			}
+		}
+	}
+
+	@Override
+	public void revert() {
+		// No revert needed
+	}
+}

--- a/src/main/java/com/alexnederlof/jasperreport/JasperConfigurator.java
+++ b/src/main/java/com/alexnederlof/jasperreport/JasperConfigurator.java
@@ -1,0 +1,9 @@
+package com.alexnederlof.jasperreport;
+
+public interface JasperConfigurator {
+
+	void configure(JasperReporter reporter);
+	
+	void revert();
+	
+}

--- a/src/main/java/com/alexnederlof/jasperreport/Version.java
+++ b/src/main/java/com/alexnederlof/jasperreport/Version.java
@@ -1,0 +1,61 @@
+package com.alexnederlof.jasperreport;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class Version implements Comparable<Version> {
+	
+	private static final Pattern VERSION_PATTERN
+		= Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)");
+
+	private final int major;
+	private final int minor;
+	private final int patch;
+
+	public Version(int major, int minor, int patch) {
+		this.major = major;
+		this.minor = minor;
+		this.patch = patch;
+	}
+
+	/**
+	 * @throws Exception when str parameter contains malformed version.
+	 *         Correct form is defined by regex "\d+\.\d+\.\d+".
+	 */
+	public static Version version(String str) throws Exception {
+
+		Matcher matcher = VERSION_PATTERN.matcher(str);
+		if (!matcher.matches()) {
+			throw new Exception("Malformed version \"" + str + "\".");
+		}
+		
+		return new Version(
+			Integer.valueOf(matcher.group(1)), Integer.valueOf(matcher.group(2)), Integer.valueOf(matcher.group(3)));
+	}
+
+	public static Version version(int major, int minor, int patch) {
+		return new Version(major, minor, patch);
+	}
+	
+	public int compareTo(Version o) {
+		
+		if (o == this) {
+			return 0;
+		}
+		
+		if (o == null) {
+			return -1;
+		}
+		
+		if (major == o.major) {
+			if (minor == o.minor) {
+				if (patch == o.patch) {
+					return 0;
+				}
+				return patch > o.patch ? 1 : -1;
+			}
+			return minor > o.minor ? 1 : -1;
+		}
+		return major > o.major ? 1 : -1;
+	}
+}


### PR DESCRIPTION
Please have a look at my changes. My projects uses JR version 3.7.6 so your plugin did not work for me. After short analysis I found out that what is different is how JR compiler is initialized. I abstracted configuration to different files. Proper configuration file is selected based on target project's jasper dependency version. I did not tested it with JR version 6 though I am pretty sure it will work. If you have any comments which you want to share please do so. If you like the idea feel free to incorporate it into original source.
