### PR TITLE
Fix incorrect default output directory. See #27

### DIFF
--- a/src/main/java/com/alexnederlof/jasperreport/JasperReporter.java
+++ b/src/main/java/com/alexnederlof/jasperreport/JasperReporter.java
@@ -65,7 +65,7 @@ public class JasperReporter extends AbstractMojo {
 	/**
 	 * This is where the .jasper files are written.
 	 *
-	 * @parameter property="${project.build.outputDirectory}/jasper"
+	 * @parameter expression="${project.build.outputDirectory}/jasper"
 	 */
 	private File outputDirectory;
 


### PR DESCRIPTION
Fixed default output directory.

`@parameter property="${project.build.outputDirectory}/jasper"` was incorrectly used here. `property` should be used for simple properties and its value should contain `${}`. Valid usage of `property` is for instance `@parameter property="project.build.outputDirectory"`.

The output directory is now correctly placed in `target/classes/jasper` by default. Tested with Maven 3.2.5.

See issue #27 for more details.