### PR TITLE
Added `failOnMissingSourceDirectory" property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ new OSS release system instead of the old OSS parent pom.
 
 # 1.8
 
-- Fixes [#7](https://github.com/alexnederlof/Jasper-report-maven-plugin/issues/7) For each `.jrxml` file search th compiled .jasper if not found or older than source file recompile it.
+- Fixes [#7](https://github.com/alexnederlof/Jasper-report-maven-plugin/issues/7) For each `.jrxml` file search the compiled .jasper if not found or older than source file recompile it.
 - Fixes [#9](https://github.com/alexnederlof/Jasper-report-maven-plugin/issues/9) Project classpath added to ClassLoader.
 
 Thanks to [@lucarota](https://github.com/lucarota)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1 [unreleased]
+
+- Added `failOnMissingSourceDirectory` property, so that one can continue the build while sourceDirectory does not exist.
+
 # 2.0
 
 This release sets Jasper to version 6 and updates some other deps. Also uses the 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You can use the plugin by adding it to the plug-in section in your pom;
 				<xmlValidation>true</xmlValidation>
 				<verbose>false</verbose>
 				<numberOfThreads>4</numberOfThreads>
+				<failOnMissingSourceDirectory>true</failOnMissingSourceDirectory>
 			</configuration>
 		</plugin>
 	</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -218,4 +218,15 @@
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
+
+	<repositories>
+		<repository>
+			<id>jasperreports</id>
+			<url>http://jasperreports.sourceforge.net/maven2</url>
+		</repository>
+		<repository>
+			<id>jaspersoft-third-party</id>
+			<url>http://jaspersoft.artifactoryonline.com/jaspersoft/third-party-ce-artifacts/</url>
+		</repository>
+	</repositories>
 </project>

--- a/src/main/java/com/alexnederlof/jasperreport/JasperReporter.java
+++ b/src/main/java/com/alexnederlof/jasperreport/JasperReporter.java
@@ -166,7 +166,7 @@ public class JasperReporter extends AbstractMojo {
 		checkOutDirWritable(outputDirectory);
 
 		SourceMapping mapping = new SuffixMapping(sourceFileExt, outputFileExt);
-        Set<File> sources = jxmlFilesToCompile(mapping);
+        Set<File> sources = jrxmlFilesToCompile(mapping);
         if (sources.isEmpty()) {
             log.info( "Nothing to compile - all Jasper reports are up to date" );
         } else {
@@ -198,7 +198,7 @@ public class JasperReporter extends AbstractMojo {
      * @return set of jxml files to compile
      * @throws MojoExecutionException When there's trouble with the input
      */
-    protected Set<File> jxmlFilesToCompile(SourceMapping mapping) throws MojoExecutionException {
+    protected Set<File> jrxmlFilesToCompile(SourceMapping mapping) throws MojoExecutionException {
 		if (!sourceDirectory.isDirectory()) {
 			String message = sourceDirectory.getName() + " is not a directory";
 			if (failOnMissingSourceDirectory) {

--- a/src/main/java/com/alexnederlof/jasperreport/JasperReporter.java
+++ b/src/main/java/com/alexnederlof/jasperreport/JasperReporter.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +32,6 @@ import net.sf.jasperreports.engine.design.JRCompiler;
 import net.sf.jasperreports.engine.design.JRJdtCompiler;
 import net.sf.jasperreports.engine.xml.JRReportSaxParserFactory;
 
-import org.apache.commons.lang.Validate;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
@@ -142,6 +142,14 @@ public class JasperReporter extends AbstractMojo {
 	 */
 	private Map<String, String> additionalProperties;
 
+	/**
+	 * If failOnMissingSourceDirectory is on the plug-in will fail the build if source directory does not exist.
+	 * Default value is true.
+	 *
+	 * @parameter default-value="true"
+	 */
+	private boolean failOnMissingSourceDirectory = true;
+
 	private Log log;
 
 	public JasperReporter() {
@@ -191,7 +199,15 @@ public class JasperReporter extends AbstractMojo {
      * @throws MojoExecutionException When there's trouble with the input
      */
     protected Set<File> jxmlFilesToCompile(SourceMapping mapping) throws MojoExecutionException {
-        Validate.isTrue(sourceDirectory.isDirectory(), sourceDirectory.getName() + " is not a directory");
+		if (!sourceDirectory.isDirectory()) {
+			String message = sourceDirectory.getName() + " is not a directory";
+			if (failOnMissingSourceDirectory) {
+				throw new IllegalArgumentException(message);
+			} else {
+				log.warn(message + ", skip JasperReports reports compiling.");
+				return Collections.emptySet();
+			}
+		}
 
         try {
             SourceInclusionScanner scanner = new StaleSourceScanner();

--- a/src/test/java/com/alexnederlof/jasperreport/JasperReportTest.java
+++ b/src/test/java/com/alexnederlof/jasperreport/JasperReportTest.java
@@ -233,6 +233,34 @@ public class JasperReportTest extends AbstractMojoTestCase {
 	}
 
 	/**
+	 * Test that a non-existent sourceDirectory fails the build.
+	 *
+	 * @throws Exception
+	 *             When an unexpected error occurs.
+	 */
+	public void testNonExistentFolderStopBuild() throws Exception {
+		try {
+			getAndExecuteMojo(getBasedir() + "/src/test/resources/testNonExistentFolderPom.xml");
+			fail("An exception should have been thrown");
+		}
+		catch (IllegalArgumentException e) {
+			assertTrue(e.getMessage().contains("nonExistentFolder"));
+		}
+	}
+
+	/**
+	 * Test that a non-existent sourceDirectory just be skipped if failOnMissingSourceDirectory=true.
+	 *
+	 * @throws Exception
+	 *             When an unexpected error occurs.
+	 */
+	public void testNonExistentFolderAllowed() throws Exception {
+		setupSourceAndDestinationFolder("/emptyFolder", "/emptyFolder_out");
+		getAndExecuteMojo(getBasedir() + "/src/test/resources/testNonExistentFolderAllowedPom.xml");
+		assertTrue("Output folder should be empty", destinationFolder.list().length == 0);
+	}
+
+	/**
 	 * The empty folder we test on is not transported by Git. We therefor have to create it manually
 	 * to do the test.
 	 */

--- a/src/test/resources/testNonExistentFolderAllowedPom.xml
+++ b/src/test/resources/testNonExistentFolderAllowedPom.xml
@@ -1,0 +1,37 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+
+<project>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>jasperreports-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>process-sources</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<xmlValidation>true</xmlValidation>
+					<numberOfThreads>4</numberOfThreads>
+					<outputFileExt>.jasper</outputFileExt>
+					<sourceFileExt>.jrxml</sourceFileExt>
+					<sourceDirectory>target/test-classes/exampleFolders/nonExistentFolder</sourceDirectory>
+					<outputDirectory>target/unitTestReports/emptyFolder_out</outputDirectory>
+					<failOnMissingSourceDirectory>false</failOnMissingSourceDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/test/resources/testNonExistentFolderPom.xml
+++ b/src/test/resources/testNonExistentFolderPom.xml
@@ -1,0 +1,36 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+
+<project>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>jasperreports-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>process-sources</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<xmlValidation>true</xmlValidation>
+					<numberOfThreads>4</numberOfThreads>
+					<outputFileExt>.jasper</outputFileExt>
+					<sourceFileExt>.jrxml</sourceFileExt>
+					<sourceDirectory>target/test-classes/exampleFolders/nonExistentFolder</sourceDirectory>
+					<outputDirectory>target/unitTestReports/emptyFolder_out</outputDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>


### PR DESCRIPTION
So that one can continue the build while the `sourceDirectory` does not exist.
Useful for setting this plugin up in parent POM for various child projects.