### PR TITLE
Configuration option to always compile all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ You can use the plugin by adding it to the plug-in section in your pom;
 				<verbose>false</verbose>
 				<numberOfThreads>4</numberOfThreads>
 				<failOnMissingSourceDirectory>true</failOnMissingSourceDirectory>
+				<sourceScanner>org.codehaus.plexus.compiler.util.scan.StaleSourceScanner</sourceScanner>
 			</configuration>
 		</plugin>
 	</plugins>

--- a/src/main/java/com/alexnederlof/jasperreport/JasperReporter.java
+++ b/src/main/java/com/alexnederlof/jasperreport/JasperReporter.java
@@ -388,7 +388,8 @@ public class JasperReporter extends AbstractMojo {
 			return new StaleSourceScanner();
 		}
 		else if (sourceScanner.equals(SimpleSourceInclusionScanner.class.getName())) {
-			return new SimpleSourceInclusionScanner(Collections.singleton("**/*"), Collections.<String> emptySet());
+			return new SimpleSourceInclusionScanner(Collections.singleton("**/*" + sourceFileExt),
+					Collections.<String> emptySet());
 		}
 		else {
 			throw new MojoExecutionException("sourceScanner not supported: \'" + sourceScanner + "\'.");


### PR DESCRIPTION
New configuration option `<sourceScanner>` created.
Default value is `<sourceScanner>org.codehaus.plexus.compiler.util.scan.StaleSourceScanner</sourceScanner>`, to compile only changed files.
Use `<sourceScanner>org.codehaus.plexus.compiler.util.scan.SimpleSourceInclusionScanner</sourceScanner>` to compile all jasper source files