### PR TITLE
setting the compiler with language java so Jasper can find it

### DIFF
--- a/src/main/java/com/alexnederlof/jasperreport/JasperReporter.java
+++ b/src/main/java/com/alexnederlof/jasperreport/JasperReporter.java
@@ -268,7 +268,7 @@ public class JasperReporter extends AbstractMojo {
 		DefaultJasperReportsContext jrContext = DefaultJasperReportsContext.getInstance();
 
         jrContext.setProperty(JRReportSaxParserFactory.COMPILER_XML_VALIDATION, String.valueOf(xmlValidation));
-		jrContext.setProperty(JRCompiler.COMPILER_PREFIX, compiler == null ? JRJdtCompiler.class.getName() : compiler);
+		jrContext.setProperty(JRCompiler.COMPILER_PREFIX+"java", compiler == null ? JRJdtCompiler.class.getName() : compiler);
 		jrContext.setProperty(JRCompiler.COMPILER_KEEP_JAVA_FILE, Boolean.FALSE.toString());
 
 		if (additionalProperties != null) {


### PR DESCRIPTION
Hi,

I did this fix because Jasper was not finding my custom compiler, he searches by `JRCompiler.COMPILER_PREFIX+language`.

If you want to support other languages, I can do something configurable like:

```
<compilers>
 <compiler>
  <language>java</language>
  <class>className</class>
 </compiler>
</compilers>
```
