### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 This release sets Jasper to version 6 and updates some other deps. Also uses the 
 new OSS release system instead of the old OSS parent pom.
+This release requires using Maven 3.x.
 
 # 1.9
 


### PR DESCRIPTION
Specified the Maven requirement on plugin version 2.0 and above, to make it easier when reading the changelog of what we need to run the plugin.