### PR TITLE
Fixed #36 - backported to Java 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
 
 
 	<properties>
-		<maven.compiler.source>1.7</maven.compiler.source>
-		<maven.compiler.target>1.7</maven.compiler.target>
+		<maven.compiler.source>1.6</maven.compiler.source>
+		<maven.compiler.target>1.6</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>

--- a/src/main/java/com/alexnederlof/jasperreport/JasperReporter.java
+++ b/src/main/java/com/alexnederlof/jasperreport/JasperReporter.java
@@ -278,7 +278,7 @@ public class JasperReporter extends AbstractMojo {
 	}
 
     private ClassLoader getClassLoader(ClassLoader classLoader) throws MojoExecutionException {
-        List<URL> classpath = new ArrayList<>();
+        List<URL> classpath = new ArrayList<URL>();
 		if (classpathElements != null) {
 			for (String element : classpathElements) {
 				try {
@@ -324,7 +324,7 @@ public class JasperReporter extends AbstractMojo {
     }
 
 	private List<CompileTask> generateTasks(Set<File> sources, SourceMapping mapping) throws MojoExecutionException {
-		List<CompileTask> tasks = new LinkedList<>();
+		List<CompileTask> tasks = new LinkedList<CompileTask>();
 		try {
         String root = sourceDirectory.getCanonicalPath();
 


### PR DESCRIPTION
I've fixed (my own) issue #36, making the plugin use Java 1.6, and become usable for a good range of legacy applications.