### PR TITLE
Fix typo in parameter default.

### DIFF
--- a/src/main/java/com/alexnederlof/jasperreport/JasperReporter.java
+++ b/src/main/java/com/alexnederlof/jasperreport/JasperReporter.java
@@ -93,7 +93,7 @@ public class JasperReporter extends AbstractMojo {
 	 * Check the source files before compiling. Default value is true.
 	 *
 	 */
-	@Parameter(defaultValue = "tue")
+	@Parameter(defaultValue = "true")
 	private boolean xmlValidation;
 
 	/**


### PR DESCRIPTION
This is the fix for the issue found by @rdicroce in #50 
Correct the typo prevents the `xmlValidtaion` been evaluated as false, and cause following exception:

```
 Could not compile my_report.jrxml because Error creating SAX parser.
net.sf.jasperreports.engine.JRRuntimeException: Error creating SAX parser.
    at net.sf.jasperreports.engine.xml.BaseSaxParserFactory.createParser (BaseSaxParserFactory.java:123)
    at net.sf.jasperreports.engine.xml.JRXmlDigesterFactory.createParser (JRXmlDigesterFactory.java:1597)
    at net.sf.jasperreports.engine.xml.JRXmlDigesterFactory.createDigester (JRXmlDigesterFactory.java:1566)
    at net.sf.jasperreports.engine.xml.JRXmlLoader.load (JRXmlLoader.java:263)
    at net.sf.jasperreports.engine.xml.JRXmlLoader.load (JRXmlLoader.java:248)
    at net.sf.jasperreports.engine.JasperCompileManager.compileToStream (JasperCompileManager.java:307)
    at net.sf.jasperreports.engine.JasperCompileManager.compileReportToStream (JasperCompileManager.java:587)
    at com.alexnederlof.jasperreport.CompileTask.call (CompileTask.java:63)
    at com.alexnederlof.jasperreport.CompileTask.call (CompileTask.java:28)
    at java.util.concurrent.FutureTask.run (FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
    at java.lang.Thread.run (Thread.java:748)
Caused by: org.xml.sax.SAXNotSupportedException: Property 'http://java.sun.com/xml/jaxp/properties/schemaLanguage' must be set before setting property 'http://java.sun.com/xml/jaxp/properties/schemaSource'. 
    at com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.setProperty (SAXParserImpl.java:554)
    at com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl.setProperty (SAXParserImpl.java:303)
    at net.sf.jasperreports.engine.xml.BaseSaxParserFactory.configureParser (BaseSaxParserFactory.java:166)
```