### PR TITLE
Fix #72, Update to pom.xml, security fixes maven repo and junit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,11 +252,12 @@
 		</repository>
 		<repository>
 			<id>jasperreports</id>
-			<url>https://jasperreports.sourceforge.net/maven2</url>
+			<url>https://jaspersoft.jfrog.io/jaspersoft/jr-ce-releases</url>
 		</repository>
 		<repository>
 			<id>jaspersoft-third-party</id>
 			<url>https://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts/</url>
 		</repository>
 	</repositories>
+	
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
 		</repository>
 		<repository>
 			<id>jaspersoft-third-party</id>
-			<url>http://jaspersoft.artifactoryonline.com/jaspersoft/third-party-ce-artifacts/</url>
+			<url>https://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts/</url>
 		</repository>
 	</repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Using mixtures of https maven repository with http repository results into security attacks, this fix is one step to resolve it. #72 